### PR TITLE
Reverting changes2

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -99,8 +99,8 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
         ) {
             let phaseX = Swift.max(0.0, Swift.min(1.0, animator?.phaseX ?? 1.0))
             
-            let low = chart.lowestVisibleX
-            let high = chart.highestVisibleX
+            let low = Swift.max(chart.lowestVisibleX, dataSet.xMin)
+            let high = Swift.min(chart.highestVisibleX, dataSet.xMax)
             
             let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
             let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -105,9 +105,8 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
             let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
             let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)
             
-            self.min = entryFrom.map(dataSet.entryIndex(entry:)) ?? 0
-            self.max = entryTo.map(dataSet.entryIndex(entry:)) ?? 0
-
+            self.min = entryFrom == nil ? 0 : dataSet.entryIndex(entry: entryFrom!)
+            self.max = entryTo == nil ? 0 : dataSet.entryIndex(entry: entryTo!)
             range = Int(Double(self.max - self.min) * phaseX)
         }
     }


### PR DESCRIPTION
### Issue Link :link:
It reverts a change from December that we hoped you fix the crash but it didn't.
We have a Firebase [crash](https://console.firebase.google.com/project/preziba-core/crashlytics/app/ios:com.preziba.core/issues/d109f7e0ee4dffbe08d08a063d15e5ff?) that we are hoping this will fix.

### Goals :soccer:
To fix a crash when lowerBounds is not <= upperBounds

### Implementation Details :construction:
Added code to make sure lowerBounds <= upperBounds

