### PR TITLE
Attempt to fix crash

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -100,8 +100,8 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
         {
             let phaseX = Swift.max(0.0, Swift.min(1.0, animator?.phaseX ?? 1.0))
             
-            let low = chart.lowestVisibleX
-            let high = chart.highestVisibleX
+            let low = Swift.max(chart.lowestVisibleX, dataSet.xMin)
+            let high = Swift.min(chart.highestVisibleX, dataSet.xMax)
             
             let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
             let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)


### PR DESCRIPTION
Making sure that lowerBound is <= upperBound
Github discussion: https://github.com/danielgindi/Charts/pull/4687#pullrequestreview-765017432

Starting from the `signos` branch and only making one small changes to lower the impact.

@leolobato I had this idea after our Zoom call.